### PR TITLE
Add "insecureSkipVerify" option

### DIFF
--- a/traefik/DOCS.md
+++ b/traefik/DOCS.md
@@ -98,10 +98,17 @@ When this option is enabled, the forwarded headers (`X-Forwarded-*`) will not be
 
 > ___Note__ for Cloudflare `X-Forwarded-*` proxied headers to work, this must be enabled._
 
-### Option `dynamic_configuration_path` (required)
+### Option `forwarded_headers_insecure` (required)
 
-Path to the directory with the dynamic endpoint configuration.  
-See the example above. 
+Enables insecure forwarding headers.  
+When this option is enabled, the forwarded headers (`X-Forwarded-*`) will not be replaced by Traefik headers. Only enable this option when you trust your forwarding proxy.  
+
+> ___Note__ for Cloudflare `X-Forwarded-*` proxied headers to work, this must be enabled._
+
+### Option `insecure_skip_verify` (required)
+
+Disables SSL certificate verification
+Useful for self-signed certificates used by services
 
 ### Option `letsencrypt` (required)
 

--- a/traefik/config.yaml
+++ b/traefik/config.yaml
@@ -38,6 +38,7 @@ options:
   log_level: ERROR
   access_logs: false
   forwarded_headers_insecure: false
+  insecure_skip_verify: false
   dynamic_configuration_path: "/config/traefik/"
   letsencrypt:
     enabled: false
@@ -52,6 +53,7 @@ schema:
   log_level: list(TRACE|DEBUG|INFO|WARN|ERROR|FATAL|PANIC)
   access_logs: bool
   forwarded_headers_insecure: bool
+  insecure_skip_verify: bool
   dynamic_configuration_path: str
   letsencrypt:
     enabled: bool

--- a/traefik/rootfs/etc/traefik/traefik.yaml.gotmpl
+++ b/traefik/rootfs/etc/traefik/traefik.yaml.gotmpl
@@ -26,6 +26,11 @@ api:
   dashboard: true
   insecure: true
 
+{{- if has $options "insecure_skip_verify" }}
+serversTransport:
+  insecureSkipVerify: {{ $options.insecure_skip_verify }}
+{{- end }}
+
 {{ if and (has $options "letsencrypt") ($options.letsencrypt.enabled) -}}
 certificatesResolvers:
   le:


### PR DESCRIPTION
Needed a way to forward internal hosts using self-signed certificates...

There's an option for that in Traefik, but ther wasn't any way to configure it in the add-on...

Not it's possible via the `insecure_skip_verify` option