### PR TITLE
Add support for proxyProtocol

### DIFF
--- a/traefik/config.yaml
+++ b/traefik/config.yaml
@@ -54,6 +54,8 @@ schema:
   access_logs: bool
   forwarded_headers_insecure: bool
   insecure_skip_verify: bool
+  proxy_protocol_trusted_ips:
+    - str?
   dynamic_configuration_path: str
   letsencrypt:
     enabled: bool

--- a/traefik/rootfs/etc/traefik/traefik.yaml.gotmpl
+++ b/traefik/rootfs/etc/traefik/traefik.yaml.gotmpl
@@ -21,6 +21,13 @@ entryPoints:
     forwardedHeaders:
       insecure: {{ $options.forwarded_headers_insecure }}
 {{- end }}
+{{- if and (has $options "proxy_protocol_trusted_ips") (gt (len $options.proxy_protocol_trusted_ips) 0) }}
+    proxyProtocol:
+      trustedIPs:
+      {{- range $options.proxy_protocol_trusted_ips }}
+        - "{{ . }}"
+      {{- end }}
+{{- end }}
 
 api:
   dashboard: true


### PR DESCRIPTION
Hi there, I found your traefik addon, but I needed proxyProtocol support for what I want to do, so I added it. I am very thankful, that you maintain this and perform regular updates, and I would be happy, if you could include this. Thank you!

A little bit of context: Traefik inspects request to auto-detect the protocol used, so when proxyProtocol is enabled, it is allowed on port 443 in addition to https, so no additional port is required. I use this to get https in my local network directly against port 443 and from the internet using the proxy protocol and tcp passthrough.