### PR TITLE
Verify SHA256 checksum of downloaded Traefik binary

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -10,8 +10,13 @@ RUN if [ "${BUILD_ARCH}" == "aarch64" ]; then BUILD_ARCH=arm64; \
     elif [ "${BUILD_ARCH}" == "armhf" ]; then BUILD_ARCH=armv7; \
     fi && \
     apk add --no-cache nginx gomplate && \
-    wget --quiet -O /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/v${TRAEFIK_VERSION}/traefik_v${TRAEFIK_VERSION}_linux_${BUILD_ARCH}.tar.gz" && \
-    tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik && \
+    TRAEFIK_ARTIFACT="traefik_v${TRAEFIK_VERSION}_linux_${BUILD_ARCH}.tar.gz" && \
+    TRAEFIK_RELEASE_URL="https://github.com/traefik/traefik/releases/download/v${TRAEFIK_VERSION}" && \
+    cd /tmp && \
+    wget --quiet -O "${TRAEFIK_ARTIFACT}" "${TRAEFIK_RELEASE_URL}/${TRAEFIK_ARTIFACT}" && \
+    wget --quiet -O traefik_checksums.txt "${TRAEFIK_RELEASE_URL}/traefik_v${TRAEFIK_VERSION}_checksums.txt" && \
+    grep "  ${TRAEFIK_ARTIFACT}\$" traefik_checksums.txt | sha256sum -c - && \
+    tar xzvf "${TRAEFIK_ARTIFACT}" -C /usr/local/bin traefik && \
     chmod +x /usr/local/bin/traefik && \
     rm -f /tmp/*
 


### PR DESCRIPTION
# Verify SHA256 checksum of downloaded Traefik binary

## Summary

The Dockerfile currently downloads the Traefik release tarball from GitHub and extracts it directly with no integrity check. This change downloads the official `traefik_v${VERSION}_checksums.txt` file published alongside each release and runs `sha256sum -c` against it before extraction. If the tarball has been tampered with — whether by a compromised release artifact, a TLS interception during build, or a corrupt download — the build now fails instead of silently shipping an unverified binary.

## Motivation

Right now, the build trusts the TLS connection to `github.com` and nothing else. There's no way for a downstream consumer (or the maintainer) to know whether the bytes that landed in `/usr/local/bin/traefik` are the bytes Traefik released. Traefik publishes a signed-by-convention `_checksums.txt` for every release; using it gives us a deterministic, reproducible integrity check that costs one extra HTTP request and a few CPU-ms at build time.

This is a defense-in-depth fix. It doesn't replace the trust we already place in the Traefik project, but it does close the window where a single mutated artifact (or a transient network problem) could go unnoticed.

## Changes

- `Dockerfile`: download `traefik_v${TRAEFIK_VERSION}_checksums.txt` from the same release, grep the line for the current architecture's artifact, and pipe it into `sha256sum -c -`. The build fails fast if the checksum does not match or if the line is missing.
- No changes to runtime behavior, `config.yaml`, or any other files.

## Notes / trade-offs

- The checksums file is fetched from the same GitHub release as the binary, so this protects against tampering of an individual artifact and against download corruption, but not against a fully-compromised release. A stronger version would pin a checksum into `build.yaml` alongside `TRAEFIK_VERSION` and have the version-bump workflow update both atomically. Happy to do that as a follow-up if preferred — it's a small change to `traefik-update-version.yml` to also read and commit the hash.
- The `grep` pattern uses two spaces (the format `sha256sum` emits and that Traefik's checksums file uses). If a future release switches format, the build will fail loudly rather than silently skip verification.

## Testing

Local build against the current `TRAEFIK_VERSION` (3.7.1) for `amd64` succeeds and prints `traefik_v3.7.1_linux_amd64.tar.gz: OK` during the build. Tampering the downloaded tarball before the verification step causes the build to fail with `FAILED` from `sha256sum`, as expected.
