### PR TITLE
Update config.yaml

### DIFF
--- a/traefik/config.yaml
+++ b/traefik/config.yaml
@@ -29,6 +29,7 @@ ingress_entry: dashboard/
 #ingress_stream: true
 hassio_role: default
 hassio_api: true
+auth_api: true
 panel_icon: mdi:earth-arrow-right
 map:
   - config


### PR DESCRIPTION
Enable auth_api permission for Supervisor /auth endpoint

hassio_api alone doesn't grant access to http://supervisor/auth.
Adding auth_api: true so the add-on can validate HA credentials
via the Supervisor auth endpoint (used by the Traefik forwardAuth
middleware).


Corresponding Traefik dynamic configuration:

```YAML
 http:
   middlewares:
     ha-token:
       headers:
         customRequestHeaders:
           X-Supervisor-Token: "{{env "SUPERVISOR_TOKEN"}}"
     ha-auth:
       forwardAuth:
         address: "http://supervisor/auth"
         trustForwardHeader: true
     auth-chain:
       chain:
         middlewares:
           - ha-token
           - ha-auth
```